### PR TITLE
Add SignalCard component and integrate Signal context

### DIFF
--- a/app/ActivationScreen.tsx
+++ b/app/ActivationScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ScrollView, View, StyleSheet } from 'react-native';
+import SignalCard from '@/ui/components/SignalCard';
+import { useSignalContext } from '@/context/SignalContext';
+
+export default function ActivationScreen() {
+  const { getSignal } = useSignalContext();
+  const signal = getSignal(0);
+  if (!signal) return null;
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <SignalCard signal={signal} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,16 +3,19 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { SignalProvider } from '@/context/SignalContext';
 
 export default function RootLayout() {
   useFrameworkReady();
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
+      <SignalProvider>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+      </SignalProvider>
       <StatusBar style="light" backgroundColor="#000000" />
     </GestureHandlerRootView>
   );

--- a/context/SignalContext.tsx
+++ b/context/SignalContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext } from 'react';
+import { signals as SIGNALS } from '@/app/utils/crypticSignalScheduler';
+
+export interface Signal {
+  title: string;
+  phase: string;
+  urgency: string;
+  content: {
+    mainMessage: string;
+    crypticHint: string;
+    technicalData: string;
+    unlocks: string[];
+  };
+  transmissions: string[];
+}
+
+interface SignalContextValue {
+  signals: Record<number, Signal>;
+  getSignal: (index: number) => Signal | undefined;
+}
+
+const SignalContext = createContext<SignalContextValue | null>(null);
+
+export const SignalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const value: SignalContextValue = {
+    signals: SIGNALS as unknown as Record<number, Signal>,
+    getSignal: (index) => (SIGNALS as any)[index],
+  };
+
+  return <SignalContext.Provider value={value}>{children}</SignalContext.Provider>;
+};
+
+export function useSignalContext() {
+  const ctx = useContext(SignalContext);
+  if (!ctx) throw new Error('SignalContext not found');
+  return ctx;
+}

--- a/ui/components/SignalCard.tsx
+++ b/ui/components/SignalCard.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Signal } from '@/context/SignalContext';
+
+interface Props {
+  signal: Signal;
+}
+
+export default function SignalCard({ signal }: Props) {
+  const [showHint, setShowHint] = useState(false);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{signal.title}</Text>
+      <Text style={styles.meta}>Phase : {signal.phase}</Text>
+      <Text style={styles.meta}>Urgence : {signal.urgency}</Text>
+      <Text style={styles.message}>{signal.content.mainMessage}</Text>
+      {showHint && (
+        <Text style={styles.hint}>{signal.content.crypticHint}</Text>
+      )}
+      <TouchableOpacity
+        style={styles.hintToggle}
+        onPress={() => setShowHint((v) => !v)}
+      >
+        <Text style={styles.hintToggleText}>
+          {showHint ? 'Masquer indice' : 'Voir indice'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#111',
+    borderWidth: 1,
+    borderColor: '#333',
+    padding: 16,
+    borderRadius: 6,
+    marginBottom: 12,
+  },
+  title: {
+    fontFamily: 'Courier New',
+    fontSize: 16,
+    color: '#00ff41',
+    marginBottom: 8,
+  },
+  meta: {
+    fontFamily: 'Courier New',
+    fontSize: 12,
+    color: '#00ff41',
+    marginBottom: 4,
+  },
+  message: {
+    fontFamily: 'Courier New',
+    fontSize: 12,
+    color: '#ccc',
+    marginBottom: 8,
+  },
+  hint: {
+    fontFamily: 'Courier New',
+    fontSize: 12,
+    color: '#ffaa00',
+    marginBottom: 8,
+  },
+  hintToggle: {
+    backgroundColor: '#00ff41',
+    paddingVertical: 6,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    borderRadius: 4,
+  },
+  hintToggleText: {
+    fontFamily: 'Courier New',
+    fontSize: 12,
+    color: '#000',
+  },
+});


### PR DESCRIPTION
## Summary
- add SignalContext to provide signal data
- implement SignalCard component with hint toggle
- use SignalContext in app layout
- display selected Signal via SignalCard in access screen
- create ActivationScreen that shows first signal

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1d7e548832481c743fd126ebebc