### PR TITLE
Add scheduling API and notification helpers

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,0 +1,22 @@
+import { checkAndSendSignals, checkAndSendMinorSignals, User } from '../app/infrastructure/notification';
+
+// Example user store. In a real application this would come from a database.
+const users: User[] = [
+  {
+    id: 'user-1',
+    signupDate: new Date().toISOString().slice(0, 10),
+    receivedSignals: [],
+  },
+];
+
+export async function runSchedule() {
+  users.forEach((user) => {
+    checkAndSendSignals(user);
+    checkAndSendMinorSignals(user);
+  });
+}
+
+// Execute immediately if run as a script
+if (require.main === module) {
+  runSchedule();
+}

--- a/app/infrastructure/notification.ts
+++ b/app/infrastructure/notification.ts
@@ -1,0 +1,35 @@
+import { getDueSignals } from '../utils/signalScheduler';
+import { generateContextualTransmission } from '../utils/crypticSignalScheduler';
+
+export interface User {
+  id: string;
+  signupDate: string;
+  receivedSignals: number[];
+  deviceToken?: string;
+}
+
+function sendNotification(user: User, message: string) {
+  // Placeholder implementation. In a real app, integrate with Expo or another
+  // push notification service.
+  console.log(`Sending notification to ${user.id}: ${message}`);
+}
+
+export function checkAndSendSignals(user: User) {
+  const dueSignals = getDueSignals(user.receivedSignals, user.signupDate);
+
+  if (dueSignals.length === 0) {
+    return;
+  }
+
+  dueSignals.forEach((signal) => {
+    sendNotification(user, `Signal #${signal.index} disponible`);
+    if (!user.receivedSignals.includes(signal.index)) {
+      user.receivedSignals.push(signal.index);
+    }
+  });
+}
+
+export function checkAndSendMinorSignals(user: User) {
+  const message = generateContextualTransmission(user.receivedSignals);
+  sendNotification(user, message);
+}


### PR DESCRIPTION
## Summary
- add notification infrastructure with `checkAndSendSignals` and `checkAndSendMinorSignals`
- create API script `schedule.ts` to invoke scheduler logic

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1d4a0908324b896c5c92208d5e0