### PR TITLE
Add typed storage helpers

### DIFF
--- a/app/(tabs)/access.tsx
+++ b/app/(tabs)/access.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getSignupDate,
+  setSignupDate,
+  getSignalsReceived,
+  setSignalsReceived,
+} from '../infrastructure/storage';
 import { StyleSheet } from 'react-native';
 import { Lock, Shield, Eye, Zap, Radio, Globe } from 'lucide-react-native';
 
@@ -19,15 +24,14 @@ export default function AccessScreen() {
   const loadSystemState = async () => {
     try {
       // Récupérer les données stockées
-      let signupDate = await AsyncStorage.getItem('signupDate');
-      let receivedJson = await AsyncStorage.getItem('signalsReceived');
-      let received: number[] = receivedJson ? JSON.parse(receivedJson) : [];
+      let signupDate = await getSignupDate();
+      let received = await getSignalsReceived();
 
       // Première initialisation
       if (!signupDate) {
         signupDate = new Date().toISOString().slice(0, 10);
-        await AsyncStorage.setItem('signupDate', signupDate);
-        await AsyncStorage.setItem('signalsReceived', JSON.stringify([]));
+        await setSignupDate(signupDate);
+        await setSignalsReceived([]);
         received = [];
       }
 
@@ -62,12 +66,11 @@ export default function AccessScreen() {
   const receiveSignal = async (signalIndex: number) => {
     try {
       // Récupérer les signaux déjà reçus
-      const receivedJson = await AsyncStorage.getItem('signalsReceived');
-      const received: number[] = receivedJson ? JSON.parse(receivedJson) : [];
+      const received = await getSignalsReceived();
 
       // Ajouter le nouveau signal
       const newReceived = [...received, signalIndex].sort((a, b) => a - b);
-      await AsyncStorage.setItem('signalsReceived', JSON.stringify(newReceived));
+      await setSignalsReceived(newReceived);
 
       // Récupérer le contenu du signal
       const content = getSignalContent(signalIndex);

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, Dimensions, Animated, SafeAreaView } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getSignupDate,
+  getSignalsReceived,
+} from '../infrastructure/storage';
 import { getProgressStats, getTimeUntilNextSignal } from '../utils/signalScheduler';
 import { generateContextualTransmission } from '../utils/crypticSignalScheduler';
 
@@ -36,9 +39,8 @@ export default function SignalScreen() {
   // Charger l'état du système
   const loadSystemState = async () => {
     try {
-      const signupDate = await AsyncStorage.getItem('signupDate');
-      const receivedJson = await AsyncStorage.getItem('signalsReceived');
-      const received: number[] = receivedJson ? JSON.parse(receivedJson) : [];
+      const signupDate = await getSignupDate();
+      const received = await getSignalsReceived();
 
       if (signupDate) {
         // Calculer les statistiques

--- a/app/infrastructure/storage.ts
+++ b/app/infrastructure/storage.ts
@@ -1,0 +1,18 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function getSignupDate(): Promise<string | null> {
+  return AsyncStorage.getItem('signupDate');
+}
+
+export async function setSignupDate(date: string): Promise<void> {
+  await AsyncStorage.setItem('signupDate', date);
+}
+
+export async function getSignalsReceived(): Promise<number[]> {
+  const json = await AsyncStorage.getItem('signalsReceived');
+  return json ? JSON.parse(json) : [];
+}
+
+export async function setSignalsReceived(signals: number[]): Promise<void> {
+  await AsyncStorage.setItem('signalsReceived', JSON.stringify(signals));
+}

--- a/bolt signal/app/(tabs)/access.tsx
+++ b/bolt signal/app/(tabs)/access.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getSignupDate,
+  setSignupDate,
+  getSignalsReceived,
+  setSignalsReceived,
+} from '../infrastructure/storage';
 import { StyleSheet } from 'react-native';
 import { Lock, Shield, Eye, Zap, Radio, Globe } from 'lucide-react-native';
 
@@ -19,15 +24,14 @@ export default function AccessScreen() {
   const loadSystemState = async () => {
     try {
       // Récupérer les données stockées
-      let signupDate = await AsyncStorage.getItem('signupDate');
-      let receivedJson = await AsyncStorage.getItem('signalsReceived');
-      let received: number[] = receivedJson ? JSON.parse(receivedJson) : [];
+      let signupDate = await getSignupDate();
+      let received = await getSignalsReceived();
 
       // Première initialisation
       if (!signupDate) {
         signupDate = new Date().toISOString().slice(0, 10);
-        await AsyncStorage.setItem('signupDate', signupDate);
-        await AsyncStorage.setItem('signalsReceived', JSON.stringify([]));
+        await setSignupDate(signupDate);
+        await setSignalsReceived([]);
         received = [];
       }
 
@@ -62,12 +66,11 @@ export default function AccessScreen() {
   const receiveSignal = async (signalIndex: number) => {
     try {
       // Récupérer les signaux déjà reçus
-      const receivedJson = await AsyncStorage.getItem('signalsReceived');
-      const received: number[] = receivedJson ? JSON.parse(receivedJson) : [];
+      const received = await getSignalsReceived();
 
       // Ajouter le nouveau signal
       const newReceived = [...received, signalIndex].sort((a, b) => a - b);
-      await AsyncStorage.setItem('signalsReceived', JSON.stringify(newReceived));
+      await setSignalsReceived(newReceived);
 
       // Récupérer le contenu du signal
       const content = getSignalContent(signalIndex);

--- a/bolt signal/app/(tabs)/index.tsx
+++ b/bolt signal/app/(tabs)/index.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, Dimensions, Animated, SafeAreaView } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getSignupDate,
+  getSignalsReceived,
+} from '../infrastructure/storage';
 import { getProgressStats, getTimeUntilNextSignal } from '../utils/signalScheduler';
 import { generateContextualTransmission } from '../utils/crypticSignalScheduler';
 
@@ -36,9 +39,8 @@ export default function SignalScreen() {
   // Charger l'état du système
   const loadSystemState = async () => {
     try {
-      const signupDate = await AsyncStorage.getItem('signupDate');
-      const receivedJson = await AsyncStorage.getItem('signalsReceived');
-      const received: number[] = receivedJson ? JSON.parse(receivedJson) : [];
+      const signupDate = await getSignupDate();
+      const received = await getSignalsReceived();
 
       if (signupDate) {
         // Calculer les statistiques

--- a/bolt signal/app/infrastructure/storage.ts
+++ b/bolt signal/app/infrastructure/storage.ts
@@ -1,0 +1,18 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export async function getSignupDate(): Promise<string | null> {
+  return AsyncStorage.getItem('signupDate');
+}
+
+export async function setSignupDate(date: string): Promise<void> {
+  await AsyncStorage.setItem('signupDate', date);
+}
+
+export async function getSignalsReceived(): Promise<number[]> {
+  const json = await AsyncStorage.getItem('signalsReceived');
+  return json ? JSON.parse(json) : [];
+}
+
+export async function setSignalsReceived(signals: number[]): Promise<void> {
+  await AsyncStorage.setItem('signalsReceived', JSON.stringify(signals));
+}


### PR DESCRIPTION
## Summary
- implement `app/infrastructure/storage.ts` with typed helpers for `AsyncStorage`
- update screen logic to use new helpers

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: missing dependencies and typings)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1d1ba4483248649ab27e73c81b4