### PR TITLE
Add common scheduler types

### DIFF
--- a/app/(tabs)/access.tsx
+++ b/app/(tabs)/access.tsx
@@ -6,15 +6,16 @@ import { Lock, Shield, Eye, Zap, Radio, Globe } from 'lucide-react-native';
 
 import { getDueSignals, getAccessLevel, getProgressStats, getTimeUntilNextSignal } from '../utils/signalScheduler';
 import { getSignalContent, generateContextualTransmission, getStatusMessage } from '../utils/crypticSignalScheduler';
+import { MinorSignal, Signal } from '../domain/types';
 
 export default function AccessScreen() {
   const [transmission, setTransmission] = useState<string>('>>> Initialisation du terminal...');
-  const [dueSignals, setDueSignals] = useState<{ index: number; date: string }[]>([]);
+  const [dueSignals, setDueSignals] = useState<MinorSignal[]>([]);
   const [accessLevel, setAccessLevel] = useState({ level: 0, name: "PUBLIC", description: "", permissions: [] });
   const [progressStats, setProgressStats] = useState({ signalsReceived: 0, totalSignals: 9, percentage: 0 });
   const [timeUntilNext, setTimeUntilNext] = useState({ message: "Calcul en cours..." });
   const [newSignalAvailable, setNewSignalAvailable] = useState(false);
-  const [signalContent, setSignalContent] = useState(null);
+  const [signalContent, setSignalContent] = useState<Signal | null>(null);
 
   const loadSystemState = async () => {
     try {

--- a/app/domain/types.ts
+++ b/app/domain/types.ts
@@ -1,0 +1,27 @@
+export interface Puzzle {
+  id: string;
+  question: string;
+  answer: string;
+  hints?: string[];
+  solved?: boolean;
+}
+
+export interface MinorSignal {
+  index: number;
+  date: string;
+  timestamp: number;
+  daysSinceStart: number;
+}
+
+export interface Signal {
+  title: string;
+  phase: string;
+  urgency: string;
+  content: {
+    mainMessage: string;
+    crypticHint: string;
+    technicalData: string;
+    unlocks: string[];
+  };
+  transmissions: string[];
+}

--- a/app/utils/crypticSignalScheduler.ts
+++ b/app/utils/crypticSignalScheduler.ts
@@ -5,8 +5,10 @@
  * Chaque signal révèle une partie de l'histoire et débloque du contenu.
  */
 
+import { Signal, MinorSignal } from '../domain/types';
+
 // Base de données des signaux narratifs
-export const SIGNAL_DATABASE = {
+export const SIGNAL_DATABASE: Record<number, Signal> = {
   0: {
     title: "SIGNAL D'ACTIVATION",
     phase: "INITIALISATION",
@@ -175,7 +177,7 @@ export const SIGNAL_DATABASE = {
  * @param {number} signalIndex - Index du signal (0-8)
  * @returns {Object} Contenu du signal
  */
-export function getSignalContent(signalIndex) {
+export function getSignalContent(signalIndex: number): Signal | null {
   return SIGNAL_DATABASE[signalIndex] || null;
 }
 
@@ -184,7 +186,7 @@ export function getSignalContent(signalIndex) {
  * @param {Array} receivedSignals - Signaux déjà reçus
  * @returns {string} Transmission cryptique
  */
-export function generateContextualTransmission(receivedSignals = []) {
+export function generateContextualTransmission(receivedSignals: number[] = []): string {
   const maxSignal = Math.max(...receivedSignals, -1);
   let availableTransmissions = [];
   
@@ -214,7 +216,10 @@ export function generateContextualTransmission(receivedSignals = []) {
  * @param {Object} nextSignal - Prochain signal
  * @returns {string} Message d'état
  */
-export function getStatusMessage(receivedSignals = [], nextSignal = null) {
+export function getStatusMessage(
+  receivedSignals: number[] = [],
+  nextSignal: MinorSignal | null = null
+): string {
   const signalCount = receivedSignals.length;
   
   if (signalCount === 0) {
@@ -250,7 +255,7 @@ export function getStatusMessage(receivedSignals = [], nextSignal = null) {
  * @param {Array} receivedSignals - Signaux reçus
  * @returns {Array} Liste d'indices
  */
-export function getCrypticHints(receivedSignals = []) {
+export function getCrypticHints(receivedSignals: number[] = []): string[] {
   const hints = [];
   
   receivedSignals.forEach(signalIndex => {

--- a/app/utils/signalScheduler.ts
+++ b/app/utils/signalScheduler.ts
@@ -11,6 +11,8 @@
  */
 
 // Configuration temporelle des signaux
+import { MinorSignal } from '../domain/types';
+
 export const SIGNAL_CONFIG = {
   INTERVAL_DAYS: 21,
   TOTAL_SIGNALS: 9,
@@ -22,9 +24,9 @@ export const SIGNAL_CONFIG = {
  * @param {string} signupDate - Date d'inscription au format YYYY-MM-DD
  * @returns {Array} Tableau des dates de signaux
  */
-export function calculateSignalDates(signupDate) {
+export function calculateSignalDates(signupDate: string): MinorSignal[] {
   const startDate = new Date(signupDate);
-  const signalDates = [];
+  const signalDates: MinorSignal[] = [];
   
   for (let i = 0; i < SIGNAL_CONFIG.TOTAL_SIGNALS; i++) {
     const signalDate = new Date(startDate);
@@ -46,7 +48,10 @@ export function calculateSignalDates(signupDate) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Array} Signaux dus aujourd'hui
  */
-export function getDueSignals(receivedSignals = [], signupDate) {
+export function getDueSignals(
+  receivedSignals: number[] = [],
+  signupDate: string
+): MinorSignal[] {
   const today = new Date().toISOString().slice(0, 10);
   const todayTimestamp = new Date(today).getTime();
   
@@ -65,7 +70,10 @@ export function getDueSignals(receivedSignals = [], signupDate) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Object|null} Prochain signal ou null si terminé
  */
-export function getNextSignal(receivedSignals = [], signupDate) {
+export function getNextSignal(
+  receivedSignals: number[] = [],
+  signupDate: string
+): MinorSignal | null {
   const today = new Date().toISOString().slice(0, 10);
   const todayTimestamp = new Date(today).getTime();
   
@@ -85,7 +93,10 @@ export function getNextSignal(receivedSignals = [], signupDate) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Object} Temps restant formaté
  */
-export function getTimeUntilNextSignal(receivedSignals = [], signupDate) {
+export function getTimeUntilNextSignal(
+  receivedSignals: number[] = [],
+  signupDate: string
+): { days?: number; hours?: number; minutes?: number; totalMs?: number; message: string; completed?: boolean; ready?: boolean } {
   const nextSignal = getNextSignal(receivedSignals, signupDate);
   
   if (!nextSignal) {
@@ -117,7 +128,13 @@ export function getTimeUntilNextSignal(receivedSignals = [], signupDate) {
  * @param {Array} receivedSignals - Signaux reçus
  * @returns {Object} Niveau d'accès et permissions
  */
-export function getAccessLevel(receivedSignals = []) {
+export function getAccessLevel(receivedSignals: number[] = []): {
+  level: number;
+  name: string;
+  description: string;
+  permissions: string[];
+  nextUnlock: string | null;
+} {
   const signalCount = receivedSignals.length;
   
   if (signalCount === 0) {
@@ -175,7 +192,19 @@ export function getAccessLevel(receivedSignals = []) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Object} Statistiques de progression
  */
-export function getProgressStats(receivedSignals = [], signupDate) {
+export function getProgressStats(
+  receivedSignals: number[] = [],
+  signupDate: string
+): {
+  signalsReceived: number;
+  totalSignals: number;
+  percentage: number;
+  daysSinceStart: number;
+  accessLevel: number;
+  accessName: string;
+  nextSignalIndex: number | null;
+  isComplete: boolean;
+} {
   const totalSignals = SIGNAL_CONFIG.TOTAL_SIGNALS;
   const received = receivedSignals.length;
   const percentage = Math.round((received / totalSignals) * 100);


### PR DESCRIPTION
## Summary
- create `app/domain/types.ts` for shared interfaces
- migrate scheduler utilities to TypeScript using the new interfaces
- update Access screen to use typed scheduler data

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1cd7da4832494f57c07c6b9af6e