### PR TITLE
Convert scheduler utilities to TypeScript

### DIFF
--- a/app/utils/crypticSignalScheduler.ts
+++ b/app/utils/crypticSignalScheduler.ts
@@ -5,8 +5,23 @@
  * Chaque signal révèle une partie de l'histoire et débloque du contenu.
  */
 
+export interface SignalContent {
+  mainMessage: string;
+  crypticHint: string;
+  technicalData: string;
+  unlocks: string[];
+}
+
+export interface SignalEntry {
+  title: string;
+  phase: string;
+  urgency: string;
+  content: SignalContent;
+  transmissions: string[];
+}
+
 // Base de données des signaux narratifs
-export const SIGNAL_DATABASE = {
+export const SIGNAL_DATABASE: Record<number, SignalEntry> = {
   0: {
     title: "SIGNAL D'ACTIVATION",
     phase: "INITIALISATION",
@@ -175,7 +190,7 @@ export const SIGNAL_DATABASE = {
  * @param {number} signalIndex - Index du signal (0-8)
  * @returns {Object} Contenu du signal
  */
-export function getSignalContent(signalIndex) {
+export function getSignalContent(signalIndex: number): SignalEntry | null {
   return SIGNAL_DATABASE[signalIndex] || null;
 }
 
@@ -184,9 +199,9 @@ export function getSignalContent(signalIndex) {
  * @param {Array} receivedSignals - Signaux déjà reçus
  * @returns {string} Transmission cryptique
  */
-export function generateContextualTransmission(receivedSignals = []) {
+export function generateContextualTransmission(receivedSignals: number[] = []): string {
   const maxSignal = Math.max(...receivedSignals, -1);
-  let availableTransmissions = [];
+  let availableTransmissions: string[] = [];
   
   // Collecte toutes les transmissions des signaux reçus
   for (let i = 0; i <= maxSignal && i < 9; i++) {
@@ -214,7 +229,9 @@ export function generateContextualTransmission(receivedSignals = []) {
  * @param {Object} nextSignal - Prochain signal
  * @returns {string} Message d'état
  */
-export function getStatusMessage(receivedSignals = [], nextSignal = null) {
+import type { SignalDate } from './signalScheduler';
+
+export function getStatusMessage(receivedSignals: number[] = [], nextSignal: SignalDate | null = null): string {
   const signalCount = receivedSignals.length;
   
   if (signalCount === 0) {
@@ -250,8 +267,8 @@ export function getStatusMessage(receivedSignals = [], nextSignal = null) {
  * @param {Array} receivedSignals - Signaux reçus
  * @returns {Array} Liste d'indices
  */
-export function getCrypticHints(receivedSignals = []) {
-  const hints = [];
+export function getCrypticHints(receivedSignals: number[] = []): string[] {
+  const hints: string[] = [];
   
   receivedSignals.forEach(signalIndex => {
     const signal = SIGNAL_DATABASE[signalIndex];

--- a/app/utils/signalScheduler.ts
+++ b/app/utils/signalScheduler.ts
@@ -15,16 +15,52 @@ export const SIGNAL_CONFIG = {
   INTERVAL_DAYS: 21,
   TOTAL_SIGNALS: 9,
   TOTAL_DURATION_DAYS: 168, // 8 * 21 jours = ~5.5 mois
-};
+} as const;
+
+export interface SignalDate {
+  index: number;
+  date: string;
+  timestamp: number;
+  daysSinceStart: number;
+}
+
+export interface AccessLevel {
+  level: number;
+  name: string;
+  description: string;
+  permissions: string[];
+  nextUnlock: string | null;
+}
+
+export interface TimeUntilNextSignal {
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  totalMs?: number;
+  message: string;
+  completed?: boolean;
+  ready?: boolean;
+}
+
+export interface ProgressStats {
+  signalsReceived: number;
+  totalSignals: number;
+  percentage: number;
+  daysSinceStart: number;
+  accessLevel: number;
+  accessName: string;
+  nextSignalIndex: number | null;
+  isComplete: boolean;
+}
 
 /**
  * Calcule les dates de diffusion de tous les signaux
  * @param {string} signupDate - Date d'inscription au format YYYY-MM-DD
  * @returns {Array} Tableau des dates de signaux
  */
-export function calculateSignalDates(signupDate) {
+export function calculateSignalDates(signupDate: string): SignalDate[] {
   const startDate = new Date(signupDate);
-  const signalDates = [];
+  const signalDates: SignalDate[] = [];
   
   for (let i = 0; i < SIGNAL_CONFIG.TOTAL_SIGNALS; i++) {
     const signalDate = new Date(startDate);
@@ -46,7 +82,7 @@ export function calculateSignalDates(signupDate) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Array} Signaux dus aujourd'hui
  */
-export function getDueSignals(receivedSignals = [], signupDate) {
+export function getDueSignals(receivedSignals: number[] = [], signupDate: string): SignalDate[] {
   const today = new Date().toISOString().slice(0, 10);
   const todayTimestamp = new Date(today).getTime();
   
@@ -65,7 +101,7 @@ export function getDueSignals(receivedSignals = [], signupDate) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Object|null} Prochain signal ou null si terminé
  */
-export function getNextSignal(receivedSignals = [], signupDate) {
+export function getNextSignal(receivedSignals: number[] = [], signupDate: string): SignalDate | null {
   const today = new Date().toISOString().slice(0, 10);
   const todayTimestamp = new Date(today).getTime();
   
@@ -85,7 +121,7 @@ export function getNextSignal(receivedSignals = [], signupDate) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Object} Temps restant formaté
  */
-export function getTimeUntilNextSignal(receivedSignals = [], signupDate) {
+export function getTimeUntilNextSignal(receivedSignals: number[] = [], signupDate: string): TimeUntilNextSignal {
   const nextSignal = getNextSignal(receivedSignals, signupDate);
   
   if (!nextSignal) {
@@ -117,7 +153,7 @@ export function getTimeUntilNextSignal(receivedSignals = [], signupDate) {
  * @param {Array} receivedSignals - Signaux reçus
  * @returns {Object} Niveau d'accès et permissions
  */
-export function getAccessLevel(receivedSignals = []) {
+export function getAccessLevel(receivedSignals: number[] = []): AccessLevel {
   const signalCount = receivedSignals.length;
   
   if (signalCount === 0) {
@@ -175,7 +211,7 @@ export function getAccessLevel(receivedSignals = []) {
  * @param {string} signupDate - Date d'inscription
  * @returns {Object} Statistiques de progression
  */
-export function getProgressStats(receivedSignals = [], signupDate) {
+export function getProgressStats(receivedSignals: number[] = [], signupDate: string): ProgressStats {
   const totalSignals = SIGNAL_CONFIG.TOTAL_SIGNALS;
   const received = receivedSignals.length;
   const percentage = Math.round((received / totalSignals) * 100);


### PR DESCRIPTION
## Summary
- migrate `signalScheduler` and `crypticSignalScheduler` to TypeScript
- add interfaces and typed exports
- remove unused `service/signalScheduler.js`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1cb3e2c83249a1be21a687f4d96