### PR TITLE
Add skeleton domain and infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # THESIGNALV1
+
+Prototype de l'application **The Signal**. Cette version fournit les bases du domaine et de l'infrastructure décrits dans le cahier des charges.
+
+## Arborescence
+- `domain/` : logique métier et données (signaux, grades, planification)
+- `infrastructure/` : wrappers AsyncStorage et façade Bolt API
+- `ui/` : écrans React Native
+- `__tests__/` : tests unitaires (Jest)
+
+L'application est encore incomplète mais sert de point de départ.

--- a/__tests__/grade.test.ts
+++ b/__tests__/grade.test.ts
@@ -1,0 +1,8 @@
+import { calculateGrade } from '../domain/grades';
+
+test('grade progression', () => {
+  expect(calculateGrade(0).name).toBe('Initié');
+  expect(calculateGrade(3).name).toBe('Adepte');
+  expect(calculateGrade(6).name).toBe('Architecte');
+  expect(calculateGrade(9).name).toBe('Maître');
+});

--- a/domain/grades.ts
+++ b/domain/grades.ts
@@ -1,0 +1,27 @@
+import { MAJOR_SIGNALS } from './signals';
+
+export interface GradeInfo {
+  level: number;
+  name: string;
+  perks: string[];
+}
+
+const GRADE_TABLE: GradeInfo[] = [
+  { level: 0, name: 'Initié', perks: [] },
+  { level: 3, name: 'Adepte', perks: ['indice_supplémentaire'] },
+  { level: 6, name: 'Architecte', perks: ['mini_bonus'] },
+  { level: 9, name: 'Maître', perks: ['avatars', 'candidature_secrète'] },
+];
+
+export function calculateGrade(resolvedSignals: number): GradeInfo {
+  for (let i = GRADE_TABLE.length - 1; i >= 0; i--) {
+    if (resolvedSignals >= GRADE_TABLE[i].level) {
+      return GRADE_TABLE[i];
+    }
+  }
+  return GRADE_TABLE[0];
+}
+
+export function getTotalSignals() {
+  return MAJOR_SIGNALS.length;
+}

--- a/domain/scheduler.ts
+++ b/domain/scheduler.ts
@@ -1,0 +1,35 @@
+import { MAJOR_SIGNALS, MINOR_SIGNALS } from './signals';
+import { calculateGrade } from './grades';
+import { loadUserState, saveUserState } from '../infrastructure/asyncStorage';
+import { schedulePush } from '../infrastructure/boltApi';
+
+export async function checkAndSendSignals() {
+  const state = await loadUserState();
+  if (!state.signupDate) return;
+  const now = new Date();
+  const due = MAJOR_SIGNALS.filter(
+    s => s.releaseDate <= now && !state.receivedSignals.includes(s.id)
+  );
+  for (const s of due) {
+    await schedulePush('Nouveau Signal', s.puzzle.title, s.releaseDate);
+    state.receivedSignals.push(s.id);
+  }
+  const gradeInfo = calculateGrade(state.receivedSignals.length);
+  state.grade = gradeInfo.level;
+  state.perks = gradeInfo.perks;
+  await saveUserState(state);
+}
+
+export async function checkAndSendMinorSignals() {
+  const state = await loadUserState();
+  if (!state.signupDate) return;
+  const now = new Date();
+  const due = MINOR_SIGNALS.filter(
+    m => m.releaseDate <= now && !state.receivedMinorSignals.includes(m.id)
+  );
+  for (const m of due) {
+    await schedulePush('Mini Signal', m.text, m.releaseDate);
+    state.receivedMinorSignals.push(m.id);
+  }
+  await saveUserState(state);
+}

--- a/domain/signals.ts
+++ b/domain/signals.ts
@@ -1,0 +1,22 @@
+import { Signal, MinorSignal } from './types';
+
+const START_DATE = new Date('2024-01-01T00:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+export const MAJOR_SIGNALS: Signal[] = Array.from({ length: 9 }, (_, i) => ({
+  id: i,
+  releaseDate: new Date(START_DATE.getTime() + i * 21 * DAY),
+  puzzle: {
+    title: `Signal #${i + 1}`,
+    riddle: `Énigme ${i + 1}...`,
+    hint: `Indice ${i + 1}`,
+    solutionCoordinates: [48.8566 + i * 0.01, 2.3522 + i * 0.01],
+  },
+}));
+
+export const MINOR_SIGNALS: MinorSignal[] = Array.from({ length: 168 }, (_, i) => ({
+  id: i,
+  text: `Mini-signal ${i + 1}`,
+  globallySynced: i % 10 === 0,
+  releaseDate: new Date(START_DATE.getTime() + i * DAY),
+}));

--- a/domain/types.ts
+++ b/domain/types.ts
@@ -1,0 +1,32 @@
+export interface Puzzle {
+  title: string;
+  riddle: string;
+  hint: string;
+  solutionCoordinates: [number, number];
+}
+
+export interface Signal {
+  id: number;
+  releaseDate: Date;
+  puzzle: Puzzle;
+}
+
+export interface MinorSignal {
+  id: number;
+  text: string;
+  gif?: string;
+  sound?: string;
+  globallySynced?: boolean;
+  releaseDate: Date;
+}
+
+export interface UserState {
+  signupDate: Date | null;
+  activationCode?: string;
+  receivedSignals: number[];
+  receivedMinorSignals: number[];
+  cohort?: 'A' | 'B';
+  grade: number;
+  perks: string[];
+  subscriptionActive: boolean;
+}

--- a/infrastructure/asyncStorage.ts
+++ b/infrastructure/asyncStorage.ts
@@ -1,0 +1,45 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { UserState } from '../domain/types';
+
+const PREFIX = 'the_signal_v1:';
+
+export const keys = {
+  signupDate: `${PREFIX}signupDate`,
+  activationCode: `${PREFIX}activationCode`,
+  receivedSignals: `${PREFIX}receivedSignals`,
+  receivedMinor: `${PREFIX}receivedMinor`,
+  grade: `${PREFIX}grade`,
+  subscription: `${PREFIX}subscription`,
+};
+
+export async function saveUserState(state: UserState) {
+  await AsyncStorage.multiSet([
+    [keys.signupDate, state.signupDate?.toISOString() ?? ''],
+    [keys.activationCode, state.activationCode ?? ''],
+    [keys.receivedSignals, JSON.stringify(state.receivedSignals)],
+    [keys.receivedMinor, JSON.stringify(state.receivedMinorSignals)],
+    [keys.grade, state.grade.toString()],
+    [keys.subscription, JSON.stringify(state.subscriptionActive)],
+  ]);
+}
+
+export async function loadUserState(): Promise<UserState> {
+  const values = await AsyncStorage.multiGet(Object.values(keys));
+  const obj: Record<string, string | null> = {};
+  values.forEach(([k, v]) => (obj[k] = v));
+  return {
+    signupDate: obj[keys.signupDate] ? new Date(obj[keys.signupDate]!) : null,
+    activationCode: obj[keys.activationCode] ?? undefined,
+    receivedSignals: obj[keys.receivedSignals]
+      ? JSON.parse(obj[keys.receivedSignals]!)
+      : [],
+    receivedMinorSignals: obj[keys.receivedMinor]
+      ? JSON.parse(obj[keys.receivedMinor]!)
+      : [],
+    grade: Number(obj[keys.grade]) || 0,
+    perks: [],
+    subscriptionActive: obj[keys.subscription]
+      ? JSON.parse(obj[keys.subscription]!)
+      : false,
+  };
+}

--- a/infrastructure/boltApi.ts
+++ b/infrastructure/boltApi.ts
@@ -1,0 +1,16 @@
+export async function sendActivationEmail(email: string, code: string) {
+  console.log(`sendActivationEmail to ${email} with code ${code}`);
+}
+
+export async function schedulePush(title: string, body: string, when: Date) {
+  console.log(`schedulePush '${title}' at ${when.toISOString()}`);
+}
+
+export async function logAnalytics(event: string, payload?: Record<string, any>) {
+  console.log(`analytics ${event}`, payload);
+}
+
+export async function simulatePurchase(productId: string) {
+  console.log(`simulatePurchase ${productId}`);
+  return { success: true };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -44,6 +45,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.8"
   }
 }

--- a/ui/ActivationScreen.tsx
+++ b/ui/ActivationScreen.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, Text } from 'react-native';
+import { sendActivationEmail } from '../infrastructure/boltApi';
+
+export default function ActivationScreen() {
+  const [code, setCode] = useState('');
+  const [email, setEmail] = useState('');
+  const handle = async () => {
+    await sendActivationEmail(email, code);
+  };
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', padding: 20 }}>
+      <Text>Activation</Text>
+      <TextInput accessibilityLabel="email" placeholder="Email" value={email} onChangeText={setEmail} />
+      <TextInput accessibilityLabel="code" placeholder="Code" value={code} onChangeText={setCode} />
+      <Button title="Activer" onPress={handle} />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add initial domain models and signal schedules
- provide AsyncStorage and Bolt API facades
- basic grade calculation and schedulers
- jest configuration and sample test
- placeholder ActivationScreen
- update README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542365d81c832482102ba2ae56834c